### PR TITLE
PKGBUILD: Bump pkgrel to 2

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=ungoogled-chromium
 pkgver=115.0.5790.170
-pkgrel=1
+pkgrel=2
 _launcher_ver=8
 _gcc_patchset=2
 # ungoogled chromium variables


### PR DESCRIPTION
This patch updates the revision to 2 to invoke an OBS rebuild.

This is because re2 has upgraded and chromium is now failing to start.